### PR TITLE
fix: real-time queue password when created by totem

### DIFF
--- a/src/Services/Totem.API/Configuration/ApiConfiguration.cs
+++ b/src/Services/Totem.API/Configuration/ApiConfiguration.cs
@@ -24,15 +24,26 @@ namespace Totem.API.Configuration
                 {
                     if (environment.IsDevelopment())
                     {
-						var allowedOrigins = configuration.GetSection("AllowedOrigins").Get<string[]>();
-						if (allowedOrigins == null || allowedOrigins.Length == 0)
-							throw new InvalidOperationException(Errors.CorsAllowedOriginsNotConfigured);
+                        var allowedOrigins = configuration.GetSection("AllowedOrigins").Get<string[]>();
+                        if (allowedOrigins == null || allowedOrigins.Length == 0)
+                            throw new InvalidOperationException(Errors.CorsAllowedOriginsNotConfigured);
 
-						policy.WithOrigins(allowedOrigins)
-							  .AllowAnyHeader()
-							  .AllowAnyMethod()
-							  .AllowCredentials();
-					}
+                        // Only during development.
+                        if (allowedOrigins.Length == 1 && allowedOrigins[0] == "*")
+                        {
+                            policy.SetIsOriginAllowed(_ => true) 
+                                  .AllowAnyHeader()
+                                  .AllowAnyMethod()
+                                  .AllowCredentials();
+                        }
+                        else
+                        {
+                            policy.WithOrigins(allowedOrigins)
+                                  .AllowAnyHeader()
+                                  .AllowAnyMethod()
+                                  .AllowCredentials();
+                        }
+                    }
                     else
                     {
                         policy.WithOrigins("https://seusiteoficial.com")

--- a/src/Services/Totem.API/RealTime/PasswordHub.cs
+++ b/src/Services/Totem.API/RealTime/PasswordHub.cs
@@ -4,6 +4,27 @@ namespace Totem.API.RealTime
 {
     public class PasswordHub : Hub
     {
+        internal static string QueueGroup(Guid queueId) => $"queue-{queueId}";
+
+        internal static string QueueGroup(string queueId) => $"queue-{queueId}";
+
+        /// <summary>
+        /// Joins the SignalR group for the specified queue.
+        /// Called by the attendant to receive new passwords in the waiting list.
+        /// </summary>
+        public async Task JoinQueue(string queueId)
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, QueueGroup(queueId));
+        }
+
+        /// <summary>
+        /// Leaves the SignalR group for the specified queue.
+        /// </summary>
+        public async Task LeaveQueue(string queueId)
+        {
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, QueueGroup(queueId));
+        }
+
         /// <summary>
         /// Joins the SignalR group for the specified service location.
         /// Called by the attendant when they open the "Meu Guiche" screen.

--- a/src/Services/Totem.API/RealTime/SignalRNotifier.cs
+++ b/src/Services/Totem.API/RealTime/SignalRNotifier.cs
@@ -12,6 +12,13 @@ namespace Totem.API.RealTime
             _hub = hub;
         }
 
+        public Task NotifyPasswordCreatedAsync(Guid queueId, int code, DateTime createdAt, bool preferential)
+        {
+            return _hub.Clients
+                       .Group(PasswordHub.QueueGroup(queueId))
+                       .SendAsync("PasswordCreated", new { code, createdAt, preferential });
+        }
+
         public Task NotifyPasswordAssignedAsync(Guid serviceLocationId, int code, DateTime createdAt)
         {
             return _hub.Clients

--- a/src/Services/Totem.Application/Events/Notifications/IRealTimeNotifier.cs
+++ b/src/Services/Totem.Application/Events/Notifications/IRealTimeNotifier.cs
@@ -3,6 +3,11 @@ namespace Totem.Application.Events.Notifications
     public interface IRealTimeNotifier
     {
         /// <summary>
+        /// Notifies when a new password is created and added to the waiting queue.
+        /// </summary>
+        Task NotifyPasswordCreatedAsync(Guid queueId, int code, DateTime createdAt, bool preferential);
+
+        /// <summary>
         /// Notifies when a new password is assigned to a service location (guichê) by the matching engine.
         /// </summary>
         Task NotifyPasswordAssignedAsync(Guid serviceLocationId, int code, DateTime createdAt);

--- a/src/Services/Totem.Application/Services/PasswordServices/PasswordService.cs
+++ b/src/Services/Totem.Application/Services/PasswordServices/PasswordService.cs
@@ -49,6 +49,12 @@ namespace Totem.Application.Services.PasswordServices
 			if (!await _passwordRepository.UnitOfWork.CommitAsync())
 				return Unsuccessful<Guid>(Errors.ErrorSavingDatabase.ToString());
 
+			await _notifier.NotifyPasswordCreatedAsync(
+				password.QueueId,
+				password.Code,
+				password.CreatedAt,
+				password.Preferential);
+
 			await _mediator.Publish(new PasswordCreatedEvent(password.Id, password.QueueId));
 
 			return Successful(password.Id);

--- a/src/Web/src/hooks/useSignalR.ts
+++ b/src/Web/src/hooks/useSignalR.ts
@@ -3,15 +3,18 @@ import { signalRService } from "@/services/SignalRService";
 import type {
   NewPasswordAssignedPayload,
   PasswordCalledPayload,
+  PasswordCreatedPayload,
   PasswordServedPayload,
 } from "@/services/interfaces/ISignalRService";
 
 export interface UseSignalROptions {
   serviceLocationId: string | null;
+  queueId: string | null;
   onPasswordCalled?: (data: PasswordCalledPayload) => void;
   onPasswordRecalled?: (data: PasswordCalledPayload) => void;
   onPasswordServed?: (data: PasswordServedPayload) => void;
   onNewPasswordAssigned?: (data: NewPasswordAssignedPayload) => void;
+  onPasswordCreated?: (data: PasswordCreatedPayload) => void;
 }
 
 export interface UseSignalRResult {
@@ -23,38 +26,51 @@ export const useSignalR = (options: UseSignalROptions): UseSignalRResult => {
   const [isConnected, setIsConnected] = useState(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
-  // Keep the latest callbacks in a ref to avoid re-running the effect on every render
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
-  const connect = useCallback(async (serviceLocationId: string) => {
-    try {
-      setConnectionError(null);
-      await signalRService.startAsync(serviceLocationId);
-      setIsConnected(true);
-
-      if (optionsRef.current.onPasswordCalled) {
-        signalRService.onPasswordCalled(optionsRef.current.onPasswordCalled);
-      }
-      if (optionsRef.current.onPasswordRecalled) {
-        signalRService.onPasswordRecalled(optionsRef.current.onPasswordRecalled);
-      }
-      if (optionsRef.current.onPasswordServed) {
-        signalRService.onPasswordServed(optionsRef.current.onPasswordServed);
-      }
-      if (optionsRef.current.onNewPasswordAssigned) {
-        signalRService.onNewPasswordAssigned(optionsRef.current.onNewPasswordAssigned);
-      }
-    } catch (error) {
-      setIsConnected(false);
-      setConnectionError((error as Error).message ?? "Unknown connection error");
+  const registerHandlers = useCallback(() => {
+    if (optionsRef.current.onPasswordCalled) {
+      signalRService.onPasswordCalled(optionsRef.current.onPasswordCalled);
+    }
+    if (optionsRef.current.onPasswordRecalled) {
+      signalRService.onPasswordRecalled(optionsRef.current.onPasswordRecalled);
+    }
+    if (optionsRef.current.onPasswordServed) {
+      signalRService.onPasswordServed(optionsRef.current.onPasswordServed);
+    }
+    if (optionsRef.current.onNewPasswordAssigned) {
+      signalRService.onNewPasswordAssigned(optionsRef.current.onNewPasswordAssigned);
+    }
+    if (optionsRef.current.onPasswordCreated) {
+      signalRService.onPasswordCreated(optionsRef.current.onPasswordCreated);
     }
   }, []);
+
+  const connect = useCallback(
+    async (serviceLocationId: string, queueId: string | null) => {
+      try {
+        setConnectionError(null);
+        await signalRService.startAsync(serviceLocationId);
+        registerHandlers();
+
+        if (queueId) {
+          await signalRService.joinQueueAsync(queueId);
+        }
+
+        setIsConnected(true);
+      } catch (error) {
+        setIsConnected(false);
+        setConnectionError((error as Error).message ?? "Unknown connection error");
+      }
+    },
+    [registerHandlers]
+  );
 
   useEffect(() => {
     if (!options.serviceLocationId) return;
 
-    connect(options.serviceLocationId);
+    connect(options.serviceLocationId, options.queueId);
 
     return () => {
       signalRService.offAll();
@@ -62,6 +78,12 @@ export const useSignalR = (options: UseSignalROptions): UseSignalRResult => {
       setIsConnected(false);
     };
   }, [options.serviceLocationId, connect]);
+
+  useEffect(() => {
+    if (!isConnected || !options.queueId) return;
+
+    void signalRService.joinQueueAsync(options.queueId);
+  }, [isConnected, options.queueId]);
 
   return { isConnected, connectionError };
 };

--- a/src/Web/src/pages/attendance/MeuGuiche.tsx
+++ b/src/Web/src/pages/attendance/MeuGuiche.tsx
@@ -15,7 +15,8 @@ import type { QueueView } from "@/models/QueueModels";
 import type {
   PasswordCalledPayload,
   PasswordServedPayload,
-  NewPasswordAssignedPayload
+  NewPasswordAssignedPayload,
+  PasswordCreatedPayload,
 } from "@/services/interfaces/ISignalRService";
 
 // ---------------------------------------------------------------------------
@@ -118,11 +119,17 @@ export function MeuGuiche() {
     fetchData();
   }, [fetchData]);
 
+  const handlePasswordCreated = useCallback((_data: PasswordCreatedPayload) => {
+    fetchData();
+  }, [fetchData]);
+
   const { isConnected } = useSignalR({
     serviceLocationId: selectedWorkstationId,
+    queueId: selectedQueueId || null,
     onPasswordCalled: handlePasswordCalled,
     onPasswordServed: handlePasswordServed,
     onNewPasswordAssigned: handleNewPasswordAssigned,
+    onPasswordCreated: handlePasswordCreated,
   });
 
   // ---------------------------------------------------------------------------

--- a/src/Web/src/services/SignalRService.ts
+++ b/src/Web/src/services/SignalRService.ts
@@ -3,6 +3,7 @@ import type {
   ISignalRService,
   NewPasswordAssignedPayload,
   PasswordCalledPayload,
+  PasswordCreatedPayload,
   PasswordServedPayload,
 } from "./interfaces/ISignalRService";
 
@@ -11,9 +12,9 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
 class SignalRService implements ISignalRService {
   private connection: signalR.HubConnection | null = null;
   private currentServiceLocationId: string | null = null;
+  private currentQueueId: string | null = null;
 
   async startAsync(serviceLocationId: string): Promise<void> {
-    // If already connected to the same room, do nothing
     if (
       this.connection?.state === signalR.HubConnectionState.Connected &&
       this.currentServiceLocationId === serviceLocationId
@@ -21,7 +22,6 @@ class SignalRService implements ISignalRService {
       return;
     }
 
-    // Disconnect from the previous room before joining a new one
     await this.stopAsync();
 
     this.connection = new signalR.HubConnectionBuilder()
@@ -31,6 +31,10 @@ class SignalRService implements ISignalRService {
       .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
       .configureLogging(signalR.LogLevel.Information)
       .build();
+
+    this.connection.onreconnected(async () => {
+      await this.rejoinGroupsAsync();
+    });
 
     try {
       await this.connection.start();
@@ -42,15 +46,48 @@ class SignalRService implements ISignalRService {
     }
   }
 
+  async joinQueueAsync(queueId: string): Promise<void> {
+    if (this.currentQueueId === queueId) return;
+
+    if (
+      this.currentQueueId &&
+      this.connection?.state === signalR.HubConnectionState.Connected
+    ) {
+      await this.connection.invoke("LeaveQueue", this.currentQueueId);
+    }
+
+    if (this.connection?.state === signalR.HubConnectionState.Connected) {
+      await this.connection.invoke("JoinQueue", queueId);
+      this.currentQueueId = queueId;
+    }
+  }
+
+  async leaveQueueAsync(queueId: string): Promise<void> {
+    if (
+      this.currentQueueId !== queueId ||
+      this.connection?.state !== signalR.HubConnectionState.Connected
+    ) {
+      return;
+    }
+
+    await this.connection.invoke("LeaveQueue", queueId);
+    this.currentQueueId = null;
+  }
+
   async stopAsync(): Promise<void> {
     if (!this.connection) return;
 
     try {
-      if (
-        this.currentServiceLocationId &&
-        this.connection.state === signalR.HubConnectionState.Connected
-      ) {
-        await this.connection.invoke("LeaveServiceLocation", this.currentServiceLocationId);
+      if (this.connection.state === signalR.HubConnectionState.Connected) {
+        if (this.currentQueueId) {
+          await this.connection.invoke("LeaveQueue", this.currentQueueId);
+        }
+        if (this.currentServiceLocationId) {
+          await this.connection.invoke(
+            "LeaveServiceLocation",
+            this.currentServiceLocationId
+          );
+        }
       }
       await this.connection.stop();
     } catch (error) {
@@ -58,6 +95,7 @@ class SignalRService implements ISignalRService {
     } finally {
       this.connection = null;
       this.currentServiceLocationId = null;
+      this.currentQueueId = null;
     }
   }
 
@@ -77,16 +115,34 @@ class SignalRService implements ISignalRService {
     this.connection?.on("NewPasswordAssigned", callback);
   }
 
+  onPasswordCreated(callback: (data: PasswordCreatedPayload) => void): void {
+    this.connection?.on("PasswordCreated", callback);
+  }
+
   offAll(): void {
     if (!this.connection) return;
     this.connection.off("PasswordCalled");
     this.connection.off("PasswordRecalled");
     this.connection.off("PasswordServed");
     this.connection.off("NewPasswordAssigned");
+    this.connection.off("PasswordCreated");
   }
 
   isConnected(): boolean {
     return this.connection?.state === signalR.HubConnectionState.Connected;
+  }
+
+  private async rejoinGroupsAsync(): Promise<void> {
+    if (!this.connection || this.connection.state !== signalR.HubConnectionState.Connected) {
+      return;
+    }
+
+    if (this.currentServiceLocationId) {
+      await this.connection.invoke("JoinServiceLocation", this.currentServiceLocationId);
+    }
+    if (this.currentQueueId) {
+      await this.connection.invoke("JoinQueue", this.currentQueueId);
+    }
   }
 }
 

--- a/src/Web/src/services/interfaces/ISignalRService.ts
+++ b/src/Web/src/services/interfaces/ISignalRService.ts
@@ -12,14 +12,23 @@ export interface NewPasswordAssignedPayload {
   createdAt: string;
 }
 
+export interface PasswordCreatedPayload {
+  code: number;
+  createdAt: string;
+  preferential: boolean;
+}
+
 export interface ISignalRService {
   startAsync(serviceLocationId: string): Promise<void>;
   stopAsync(): Promise<void>;
+  joinQueueAsync(queueId: string): Promise<void>;
+  leaveQueueAsync(queueId: string): Promise<void>;
 
   onPasswordCalled(callback: (data: PasswordCalledPayload) => void): void;
   onPasswordRecalled(callback: (data: PasswordCalledPayload) => void): void;
   onPasswordServed(callback: (data: PasswordServedPayload) => void): void;
   onNewPasswordAssigned(callback: (data: NewPasswordAssignedPayload) => void): void;
+  onPasswordCreated(callback: (data: PasswordCreatedPayload) => void): void;
 
   offAll(): void;
   isConnected(): boolean;


### PR DESCRIPTION
Implement SignalR-based notifications for new password creation, including backend support for queue group management and frontend handling of the new PasswordCreated event. Update CORS config to allow wildcard origins only in development. Update React hooks and components to join queue groups and refresh data on new password events.